### PR TITLE
Create filtering functionality. has some bugs

### DIFF
--- a/src/Componenets/AmiiboContainer/AmiiboContainer.js
+++ b/src/Componenets/AmiiboContainer/AmiiboContainer.js
@@ -3,12 +3,11 @@ import "./AmiiboContainer.css"
 import Amiibo from "../Amiibo/Amiibo";
 import Form from "../Form/Form";
 
-const AmiiboContainer = ({amiiboData}) => {
+const AmiiboContainer = ({amiiboData, filter}) => {
     const series = amiiboData.map(amiibo => amiibo.amiiboSeries)
     const uniqueSeries = series.filter((currentSeries, index) => {
         return series.indexOf(currentSeries) === index
     })
-    console.log('series amiibos', uniqueSeries)
     const amiiboFigures = amiiboData.map(amiibo => {
         const {image, name} = amiibo
         return <Amiibo
@@ -19,7 +18,7 @@ const AmiiboContainer = ({amiiboData}) => {
     })
     return (
         <div className="amiibo-container">
-            <Form uniqueSeries={uniqueSeries}/>
+            <Form uniqueSeries={uniqueSeries} filter={filter}/>
             {amiiboFigures}
         </div>
     )

--- a/src/Componenets/App/App.js
+++ b/src/Componenets/App/App.js
@@ -4,7 +4,7 @@ import AmiiboContainer from "../AmiiboContainer/AmiiboContainer";
 import AmiiboDetails from "../AmiiboDetails/AmiiboDetails";
 import UserCollection from "../UserCollection/UserCollection";
 import AboutUs from "../AboutUs/AboutUs";
-import { Route, Switch} from 'react-router-dom';
+import { Route } from 'react-router-dom';
 
 const App = () => {
   const [amiibos, setAmiibos] = useState([])
@@ -14,9 +14,27 @@ const App = () => {
     fetch('https://www.amiiboapi.com/api/amiibo/')
     .then(res => res.json())
     .then(data => {
-      console.log(data.amiibo)
+      // console.log(data.amiibo)
       setAmiibos(data.amiibo)
     })
+  }
+
+  const filter = (characterName, characterSeries) => {
+    if(characterName && characterSeries) {
+      const filteredAmiibos = amiibos.filter(amiibo => amiibo.name.toLowerCase().startsWith(characterName.toLowerCase()) && amiibo.amiiboSeries === characterSeries)
+        return setAmiibos(filteredAmiibos)
+    }
+    else if(characterName && !characterSeries) {
+      const filteredAmiibos = amiibos.filter(amiibo => amiibo.name.toLowerCase().startsWith(characterName.toLowerCase()))
+        return setAmiibos(filteredAmiibos)
+    }
+    else if(!characterName && characterSeries) {
+      const filteredAmiibos = amiibos.filter(amiibo => amiibo.amiiboSeries === characterSeries)
+        return setAmiibos(filteredAmiibos)
+    }
+    else {
+      getAmiiboData();
+    }
   }
 
   useEffect(() => {
@@ -26,14 +44,12 @@ const App = () => {
   return (
     <div>
       <Header/>
-      {/* <Switch> */}
-        <Route exact path="/" render={() => <AmiiboContainer amiiboData={amiibos}/>}/>
-        <Route exact path="/amiiWho/:amiiboTail" render={({match}) => {
-            const foundAmiibo = amiibos.find(amiibo => amiibo.tail === match.params.amiiboTail)
-            return <AmiiboDetails amiibo={foundAmiibo}/>}}/>
-        <Route exact path="/amiiWho/myCollection" render={() => <UserCollection favoriteList={favoriteList}/>}/>
-        <Route exact path="/amiiWho/AboutUs" render={() => <AboutUs/>}/>
-      {/* </Switch> */}
+      <Route exact path="/" render={() => <AmiiboContainer amiiboData={amiibos} filter={filter}/>}/>
+      <Route exact path="/amiiWho/:amiiboTail" render={({match}) => {
+          const foundAmiibo = amiibos.find(amiibo => amiibo.tail === match.params.amiiboTail)
+          return <AmiiboDetails amiibo={foundAmiibo}/>}}/>
+      <Route exact path="/amiiWho/myCollection" render={() => <UserCollection favoriteList={favoriteList}/>}/>
+      <Route exact path="/amiiWho/AboutUs" render={() => <AboutUs/>}/>
     </div>
   )
 }

--- a/src/Componenets/Form/Form.js
+++ b/src/Componenets/Form/Form.js
@@ -1,35 +1,38 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import "./Form.css"
 
-const Form = ({uniqueSeries}) => {
-    const [amiiboName, setAmiiboName] = useState('')
-    const [amiiboSeries, setAmiiboSeries] = useState('')
+const Form = ({uniqueSeries, filter}) => {
+    const [amiiboName, setAmiiboName] = useState("")
+    const [amiiboSeries, setAmiiboSeries] = useState("")
 
     const seriesOptions = uniqueSeries.map(series => {
         return <option key={series} value={series}>{series}</option>
     })
 
-    const handleChange = (event) => {
-        const {value} = event.target
-        setAmiiboName(value)
-        setAmiiboSeries(value)
-    }
+    useEffect(() => {
+        filter(amiiboName, amiiboSeries)
+      }, [amiiboName])
+
+    useEffect(() => {
+        filter(amiiboName, amiiboSeries)
+    }, [amiiboSeries])
+
     return (
         <div className="form-container">
-            <form>
+            <form >
                 <input 
                     name="amiiboName"
                     value={amiiboName}
                     placeholder="Find Character By Name"
-                    onChange={handleChange}
+                    onChange={(event) => setAmiiboName(event.target.value)}
                 />
                 <select 
                     name="amiiboSeries"
                     value={amiiboSeries}
                     placeholder="Find Amiibos By Series"
-                    onChange={handleChange}
+                    onChange={(event) => setAmiiboSeries(event.target.value)}
                 >
-                    <option disabled value="">Find Amiibo By Series</option>
+                    <option value="">Find Amiibo By Series</option>
                         {seriesOptions}  
                 </select>
             </form>


### PR DESCRIPTION
This pull request allows users to filter amiibos by name and their series. 

bugs: when a user filters an amiibo by name, the series filter shrinks to a few series that correspond to the new amiibo data that was filtered

ideas for fixes: have another state for amiibo series. when the amiibo data is fetched, filter out the unigue series and set the state so that the input wont change when a name of an amiibo is inputted. 